### PR TITLE
Fix deprecated code and incorrect paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore IDE config files
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # ignore IDE config files
 .idea/
+
+# ignore python cache files
+**/__pycache__/**

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+lxml = "*"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,93 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8118d70d965696e12ad7371d7d21543b3b345903922511bbf677810d1a72d917"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:02bc220d61f46e9b9d5a53c361ef95e9f5e1d27171cd461dddb17677ae2289a5",
+                "sha256:22f253b542a342755f6cfc047fe4d3a296515cf9b542bc6e261af45a80b8caf6",
+                "sha256:2f31145c7ff665b330919bfa44aacd3a0211a76ca7e7b441039d2a0b0451e415",
+                "sha256:36720698c29e7a9626a0dc802ef8885f8f0239bfd1689628ecd459a061f2807f",
+                "sha256:438a1b0203545521f6616132bfe0f4bca86f8a401364008b30e2b26ec408ce85",
+                "sha256:4815892904c336bbaf73dafd54f45f69f4021c22b5bad7332176bbf4fb830568",
+                "sha256:5be031b0f15ad63910d8e5038b489d95a79929513b3634ad4babf77100602588",
+                "sha256:5c93ae37c3c588e829b037fdfbd64a6e40c901d3f93f7beed6d724c44829a3ad",
+                "sha256:60842230678674cdac4a1cf0f707ef12d75b9a4fc4a565add4f710b5fcf185d5",
+                "sha256:62939a8bb6758d1bf923aa1c13f0bcfa9bf5b2fc0f5fa917a6e25db5fe0cfa4e",
+                "sha256:75830c06a62fe7b8fe3bbb5f269f0b308f19f3949ac81cfd40062f47c1455faf",
+                "sha256:81992565b74332c7c1aff6a913a3e906771aa81c9d0c68c68113cffcae45bc53",
+                "sha256:8c892fb0ee52c594d9a7751c7d7356056a9682674b92cc1c4dc968ff0f30c52f",
+                "sha256:9d862e3cf4fc1f2837dedce9c42269c8c76d027e49820a548ac89fdcee1e361f",
+                "sha256:a623965c086a6e91bb703d4da62dabe59fe88888e82c4117d544e11fd74835d6",
+                "sha256:a7783ab7f6a508b0510490cef9f857b763d796ba7476d9703f89722928d1e113",
+                "sha256:aab09fbe8abfa3b9ce62aaf45aca2d28726b1b9ee44871dbe644050a2fff4940",
+                "sha256:abf181934ac3ef193832fb973fd7f6149b5c531903c2ec0f1220941d73eee601",
+                "sha256:ae07fa0c115733fce1e9da96a3ac3fa24801742ca17e917e0c79d63a01eeb843",
+                "sha256:b9c78242219f674ab645ec571c9a95d70f381319a23911941cd2358a8e0521cf",
+                "sha256:bccb267678b870d9782c3b44d0cefe3ba0e329f9af8c946d32bf3778e7a4f271",
+                "sha256:c4df4d27f4c93b2cef74579f00b1d3a31a929c7d8023f870c4b476f03a274db4",
+                "sha256:caf0e50b546bb60dfa99bb18dfa6748458a83131ecdceaf5c071d74907e7e78a",
+                "sha256:d3266bd3ac59ac4edcd5fa75165dee80b94a3e5c91049df5f7c057ccf097551c",
+                "sha256:db0d213987bcd4e6d41710fb4532b22315b0d8fb439ff901782234456556aed1",
+                "sha256:dbbd5cf7690a40a9f0a9325ab480d0fccf46d16b378eefc08e195d84299bfae1",
+                "sha256:e16e07a0ec3a75b5ee61f2b1003c35696738f937dc8148fbda9fe2147ccb6e61",
+                "sha256:e175a006725c7faadbe69e791877d09936c0ef2cf49d01b60a6c1efcb0e8be6f",
+                "sha256:edd9c13a97f6550f9da2236126bb51c092b3b1ce6187f2bd966533ad794bbb5e",
+                "sha256:fa39ea60d527fbdd94215b5e5552f1c6a912624521093f1384a491a8ad89ad8b"
+            ],
+            "index": "pypi",
+            "version": "==4.2.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ $ pipenv install
 
 ### Install python modules manually
 
-If you have trouble with **pipenv** or simply do not want to use it. You may also install the dependencies manually using:
+Alternatively, if you have trouble with **pipenv** or simply do not want to use it. You may also install the dependencies manually using:
 
 ```bash
 $ pip install <package_name> 
 ```
 
-The list of dependencies is specified in the *Packages* section inside [Pipfile](Pipfile).
+The list of dependencies is specified in the ***packages*** section inside [Pipfile](Pipfile).
   
 
 ### Install MetaMap (needed only if choosing MetaMap as NLP)

--- a/README.md
+++ b/README.md
@@ -11,12 +11,22 @@ EHR-Phenolyzer is a python pipeline to automatically translate raw clinical note
 5. linux environment
 
 ## INSTALLATION
+
 ### Install python modules
+
+This project manages a Python virtual environment with **pipenv**. If you don't have **pipenv** in your local environment, you may install it with:
+
 ```bash
-$pip install requests
-$pip install lxml
-$pip install urllib3
+$ pip install pipenv
 ```
+
+Then you can create an exact copy of this project's dependencies using:
+
+```bash
+$ pipenv install 
+```
+
+*hint: the virtual environment is build on Python 3.6, you will need to have Python 3.6 in your local environment. Otherwise, you may download it from [https://www.python.org/downloads/](https://www.python.org/downloads/)*  
 
 ### Install MetaMap (needed only if choosing MetaMap as NLP)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ Then you can create an exact copy of this project's dependencies using:
 $ pipenv install 
 ```
 
-*hint: the virtual environment is build on Python 3.6, you will need to have Python 3.6 in your local environment. Otherwise, you may download it from [https://www.python.org/downloads/](https://www.python.org/downloads/)*  
+*hint: the virtual environment is build on Python 3.6, you will need to have Python 3.6 in your local environment. Otherwise, you may download it from [https://www.python.org/downloads/](https://www.python.org/downloads/)*
+
+### Install python modules manually
+
+If you have trouble with **pipenv** or simply do not want to use it. You may also install the dependencies manually using:
+
+```bash
+$ pip install <package_name> 
+```
+
+The list of dependencies is specified in the *Packages* section inside [Pipfile](Pipfile).
+  
 
 ### Install MetaMap (needed only if choosing MetaMap as NLP)
 

--- a/lib/hpo_phenolyzer.py
+++ b/lib/hpo_phenolyzer.py
@@ -2,7 +2,7 @@ import argparse,os,subprocess
 import glob,sys,distutils.spawn
 import pymetamap as pt
 import sys
-from hpo_obo import Obo
+from lib.hpo_obo import Obo
 
 
 ###parse the arguments

--- a/lib/hpo_phenolyzer.py
+++ b/lib/hpo_phenolyzer.py
@@ -1,6 +1,5 @@
 import argparse,os,subprocess
 import glob,sys,distutils.spawn
-import pymetamap as pt
 import sys
 from lib.hpo_obo import Obo
 

--- a/lib/pymetamap.py
+++ b/lib/pymetamap.py
@@ -9,7 +9,7 @@ def run_command(command_line):
 
 #Remove abnormal characters in the input file, otherwise will lead to system error for metamap
 #TODO: consider more cases
-def format_input(notes_file,outdir):
+def format_input(filename,outdir):
     def removeNonAscii(s):
         return "".join(i for i in s if ord(i)<128)
 

--- a/lib/pymetamap.py
+++ b/lib/pymetamap.py
@@ -1,7 +1,7 @@
 import os
-from parse_metamap_output import OutputParser
+from lib.parse_metamap_output import OutputParser
 #import obo as ob # obo from third party, TODO: write my own obo file parser
-from hpo_obo import Obo
+from lib.hpo_obo import Obo
 
 def run_command(command_line):
     return os.popen(command_line).read()

--- a/lib/pyncbo_annotator.py
+++ b/lib/pyncbo_annotator.py
@@ -1,6 +1,6 @@
 import os,json,sys
 from urllib.request import build_opener, quote
-from hpo_obo import Obo
+from lib.hpo_obo import Obo
 
 
 

--- a/lib/pyncbo_annotator.py
+++ b/lib/pyncbo_annotator.py
@@ -1,4 +1,5 @@
-import os,json,urllib2,sys
+import os,json,sys
+from urllib.request import build_opener, quote
 from hpo_obo import Obo
 
 
@@ -34,9 +35,9 @@ def run_ncbo_annotator(notes_file="example/Bourne_OPA3.txt",prefix="ncbo",obo_fi
     op=Obo(obo_file)
     id2name_dict=op.id2name()
     #get json from ncbo annotator web service
-    bopen=urllib2.build_opener()
+    bopen=build_opener()
     bopen.addheaders=[('Authorization','apikey token=' + api_key)]
-    url_info="http://data.bioontology.org"+"/annotator?longest_only=true&ontologies=HP&text=" + urllib2.quote(notes_text)
+    url_info="http://data.bioontology.org"+"/annotator?longest_only=true&ontologies=HP&text=" + quote(notes_text)
     ncbo_json=json.loads(bopen.open(url_info).read())
     unique_ids={}
     for records in ncbo_json:

--- a/test/test_hpo_obo.py
+++ b/test/test_hpo_obo.py
@@ -4,7 +4,7 @@ def load_src(name, fpath):
         else os.path.join(os.path.dirname(__file__), fpath)
     return imp.load_source(name, p)
 load_src("hpo_obo","../lib/hpo_obo.py")
-import hpo_obo as ho
+import lib.hpo_obo as ho
 import unittest
 obj=ho.Obo("../db/hp.obo")
 


### PR DESCRIPTION
This PR addresses the following issues:

- The code in `/lib/` folder uses paths relative to the `/lib` folder thus the code cannot run from the root folder as instructed in the README.
- The code uses a deprecated library `urllib2` which has been split across several modules in Python 3 named `urllib.request` and `urllib.error`.

In addition, this PR uses **pipenv** to manage a Python environment which allows the user to create an exact copy of the project's dependencies in an isolated environment. 

**README** has also been updated accordingly.